### PR TITLE
feat: add toggle for view count display in shorts controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 Add a control bar below videos from YouTube Shorts.
 
+Features:
+- Control bar with play/pause, volume, and fullscreen controls
+- Display of current time and total duration
+- Display of video view count
+- Keyboard shortcuts
+
 Keyboard shortcuts:
 
 - Left/Right arrow keys to rewind/fast-forward the video by 5 seconds.

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -29,6 +29,9 @@
   "DisableInfiniteLoop": {
     "message": "Disable Infinite Loop"
   },
+  "ShowViewCount": {
+    "message": "Show view count"
+  },
   "SupportMe": {
     "message": "Support me ❤"
   },

--- a/css/content_script.css
+++ b/css/content_script.css
@@ -193,4 +193,25 @@ ytd-shorts[cfyts-enabled=false] .cfyts-player-controls {
   font-size: 13px;
 }
 
+.cfyts-player-controls .control-buttons .view-count-display {
+  font-family: "YouTube Noto", Roboto, Arial, Helvetica, sans-serif;
+  font-size: 13px;
+  margin-left: 10px;
+  color: rgba(255, 255, 255, 0.9);
+  display: flex;
+  align-items: center;
+  font-weight: 500;
+  background-color: rgba(0, 0, 0, 0.5);
+  padding: 2px 6px;
+  border-radius: 4px;
+  max-width: 150px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+ytd-shorts[cfyts-enabled=true][cfyts-show-view-count=false] .cfyts-player-controls .view-count-display {
+  display: none !important;
+}
+
 /*# sourceMappingURL=content_script.css.map */

--- a/html/popup.html
+++ b/html/popup.html
@@ -83,6 +83,19 @@
             />
           </label>
         </div>
+
+        <div class="form-check" data-bs-theme="dark">
+          <label class="form-check-label">
+            <span data-i18n="ShowViewCount">Show view count</span>
+            <input
+              type="checkbox"
+              class="form-check-input"
+              id="show_view_count"
+              value="checkedValue"
+              checked
+            />
+          </label>
+        </div>
       </div>
     </div>
 

--- a/js/content_script.js
+++ b/js/content_script.js
@@ -13,6 +13,7 @@ chrome.storage.sync
     controlVolumeWithArrows: false,
     disableInfiniteLoop: false,
     hideDefaultControls: true,
+    showViewCount: true,
   })
   .then((items) => {
     /** @type {YTShortsPlayer | null} */
@@ -98,6 +99,7 @@ chrome.storage.sync
       if (player) {
         player.controlVolumeWithArrows = items.controlVolumeWithArrows;
         player.enabled = items.enabled;
+        player.showViewCount = items.showViewCount;
 
         const disableInfiniteLoop = items.enabled && items.disableInfiniteLoop;
 
@@ -127,6 +129,11 @@ chrome.storage.sync
       ytShortsPageElement.setAttribute(
         'cfyts-hide-default-controls',
         items.hideDefaultControls.toString(),
+      );
+      
+      ytShortsPageElement.setAttribute(
+        'cfyts-show-view-count',
+        items.showViewCount.toString(),
       );
     }
 
@@ -256,6 +263,7 @@ chrome.storage.sync
         items.controlVolumeWithArrows,
         items.enabled,
         items.disableInfiniteLoop,
+        items.showViewCount,
       );
 
       devLog('player added.');

--- a/js/player.js
+++ b/js/player.js
@@ -8,6 +8,7 @@ class YTShortsPlayer {
    * @param {boolean} [controlVolumeWithArrows]
    * @param {boolean} [enabled]
    * @param {boolean} [disableInfiniteLoop]
+   * @param {boolean} [showViewCount]
    * */
   constructor(
     video,
@@ -18,6 +19,7 @@ class YTShortsPlayer {
     controlVolumeWithArrows = false,
     enabled = true,
     disableInfiniteLoop = false,
+    showViewCount = true,
   ) {
     this.video = video;
     this.container = container;
@@ -27,6 +29,7 @@ class YTShortsPlayer {
     this.controlVolumeWithArrows = controlVolumeWithArrows;
     this.disableInfiniteLoop = disableInfiniteLoop;
     this.enabled = enabled;
+    this.showViewCount = showViewCount;
 
     /** @type {HTMLButtonElement | null} */
     this.fullScreenButton = null;
@@ -137,12 +140,14 @@ class YTShortsPlayer {
     const playButton = this.createPlayButton(controls);
     const volumeControl = this.createVolumeControl(controls);
     const timeDisplay = this.createTimeDisplay(controls);
+    const viewCount = this.createViewCount(controls);
     const fullscreenButton = this.createFullscreenButton(controls);
 
     if (created) {
       controlButtons.appendChild(playButton);
       controlButtons.appendChild(volumeControl);
       controlButtons.appendChild(timeDisplay);
+      controlButtons.appendChild(viewCount);
 
       // create space between the controls and the full screen button.
       const spacer = document.createElement('div');
@@ -335,23 +340,139 @@ class YTShortsPlayer {
     }
 
     const updateTimeDisplay = () => {
-      const duration = this.video.duration;
-      const currentTime = this.video.currentTime;
+      if (isExtensionDisabledOrReloaded()) return;
+      if (!this.video) return;
 
-      // format current time as mm:ss
-      const currentTimeFormatted = formatTime(currentTime);
-      const durationFormatted = formatTime(duration);
-
-      timeDisplay.textContent = `${currentTimeFormatted} / ${durationFormatted}`;
+      timeDisplay.textContent = `${formatTime(
+        this.video.currentTime,
+      )} / ${formatTime(this.video.duration)}`;
     };
 
     updateTimeDisplay();
+
     this.video.addEventListener('timeupdate', (e) => {
       if (isExtensionDisabledOrReloaded()) return;
       updateTimeDisplay();
     });
 
+    this.video.addEventListener('loadedmetadata', (e) => {
+      if (isExtensionDisabledOrReloaded()) return;
+      updateTimeDisplay();
+    });
+
     return timeDisplay;
+  }
+
+  /** @param {HTMLDivElement} controls */
+  createViewCount(controls) {
+    let viewCountDisplay = controls.querySelector('.view-count-display');
+
+    if (!viewCountDisplay) {
+      viewCountDisplay = document.createElement('div');
+      viewCountDisplay.classList.add('view-count-display');
+    }
+
+    // Atualizar a visibilidade com base na configuração
+    const updateViewCountVisibility = () => {
+      if (this.showViewCount) {
+        viewCountDisplay.style.display = '';
+      } else {
+        viewCountDisplay.style.display = 'none';
+      }
+    };
+
+    // Atualizar inicialmente a visibilidade
+    updateViewCountVisibility();
+
+    const updateViewCount = () => {
+      if (isExtensionDisabledOrReloaded()) return;
+      if (!this.showViewCount) return;
+      
+      // Lista de possíveis seletores para encontrar a contagem de visualizações
+      const selectors = [
+        // Seletor do Better YT Shorts
+        {
+          query: "#factoids > view-count-factoid-renderer > factoid-renderer > div",
+          getAttribute: "aria-label"
+        },
+        // Seletor alternativo 1
+        {
+          query: "#shorts-container .ytd-reel-player-overlay-renderer #info-text",
+          getAttribute: null
+        },
+        // Seletor alternativo 2
+        {
+          query: "#metadata-line > span:first-child",
+          getAttribute: null
+        },
+        // Seletor alternativo 3
+        {
+          query: "ytd-reel-player-header-renderer #info ytd-badge-supported-renderer yt-formatted-string",
+          getAttribute: null
+        },
+        // Seletor alternativo 4
+        {
+          query: ".view-count.ytd-video-view-count-renderer",
+          getAttribute: null
+        }
+      ];
+      
+      // Tentar cada seletor até encontrar um que funcione
+      for (const selector of selectors) {
+        const element = document.querySelector(selector.query);
+        if (!element) continue;
+        
+        let viewText = '';
+        if (selector.getAttribute) {
+          viewText = element.getAttribute(selector.getAttribute) || '';
+        } else {
+          viewText = element.textContent || '';
+        }
+        
+        viewText = viewText.trim();
+        if (viewText) {
+          viewCountDisplay.textContent = viewText;
+          return; // Encerrar função após encontrar o primeiro valor válido
+        }
+      }
+      
+      // Se chegou aqui, nenhum seletor funcionou
+      viewCountDisplay.textContent = '';
+    };
+
+    // Configurar para reagir à mudança na configuração
+    Object.defineProperty(this, 'showViewCount', {
+      get: function() {
+        return this._showViewCount;
+      },
+      set: function(value) {
+        this._showViewCount = value;
+        updateViewCountVisibility();
+        if (value) updateViewCount();
+      }
+    });
+
+    // Atualizar inicialmente
+    updateViewCount();
+
+    // Configurar um MutationObserver abrangente para detectar mudanças no documento
+    const observer = new MutationObserver(() => {
+      requestAnimationFrame(() => {
+        updateViewCount();
+      });
+    });
+      
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['aria-label']
+    });
+
+    // Também atualizar quando o vídeo mudar
+    this.video.addEventListener('loadeddata', updateViewCount);
+    
+    return viewCountDisplay;
   }
 
   /** @param {HTMLDivElement} controls */

--- a/js/player.js
+++ b/js/player.js
@@ -372,7 +372,7 @@ class YTShortsPlayer {
       viewCountDisplay.classList.add('view-count-display');
     }
 
-    // Atualizar a visibilidade com base na configuração
+    // Update visibility based on configuration
     const updateViewCountVisibility = () => {
       if (this.showViewCount) {
         viewCountDisplay.style.display = '';
@@ -381,43 +381,43 @@ class YTShortsPlayer {
       }
     };
 
-    // Atualizar inicialmente a visibilidade
+    // Update visibility initially
     updateViewCountVisibility();
 
     const updateViewCount = () => {
       if (isExtensionDisabledOrReloaded()) return;
       if (!this.showViewCount) return;
       
-      // Lista de possíveis seletores para encontrar a contagem de visualizações
+      // List of possible selectors to find the view count
       const selectors = [
-        // Seletor do Better YT Shorts
+        // views selector
         {
           query: "#factoids > view-count-factoid-renderer > factoid-renderer > div",
           getAttribute: "aria-label"
         },
-        // Seletor alternativo 1
+        // Alternative selector 1
         {
           query: "#shorts-container .ytd-reel-player-overlay-renderer #info-text",
           getAttribute: null
         },
-        // Seletor alternativo 2
+        // Alternative selector 2
         {
           query: "#metadata-line > span:first-child",
           getAttribute: null
         },
-        // Seletor alternativo 3
+        // Alternative selector 3
         {
           query: "ytd-reel-player-header-renderer #info ytd-badge-supported-renderer yt-formatted-string",
           getAttribute: null
         },
-        // Seletor alternativo 4
+        // Alternative selector 4
         {
           query: ".view-count.ytd-video-view-count-renderer",
           getAttribute: null
         }
       ];
       
-      // Tentar cada seletor até encontrar um que funcione
+      // Try each selector until finding one that works
       for (const selector of selectors) {
         const element = document.querySelector(selector.query);
         if (!element) continue;
@@ -432,15 +432,15 @@ class YTShortsPlayer {
         viewText = viewText.trim();
         if (viewText) {
           viewCountDisplay.textContent = viewText;
-          return; // Encerrar função após encontrar o primeiro valor válido
+          return; // Exit function after finding the first valid value
         }
       }
       
-      // Se chegou aqui, nenhum seletor funcionou
+      // If we got here, no selector worked
       viewCountDisplay.textContent = '';
     };
 
-    // Configurar para reagir à mudança na configuração
+    // Set up to react to configuration changes
     Object.defineProperty(this, 'showViewCount', {
       get: function() {
         return this._showViewCount;
@@ -452,10 +452,10 @@ class YTShortsPlayer {
       }
     });
 
-    // Atualizar inicialmente
+    // Update initially
     updateViewCount();
 
-    // Configurar um MutationObserver abrangente para detectar mudanças no documento
+    // Set up a comprehensive MutationObserver to detect document changes
     const observer = new MutationObserver(() => {
       requestAnimationFrame(() => {
         updateViewCount();
@@ -469,7 +469,7 @@ class YTShortsPlayer {
       attributeFilter: ['aria-label']
     });
 
-    // Também atualizar quando o vídeo mudar
+    // Also update when the video changes
     this.video.addEventListener('loadeddata', updateViewCount);
     
     return viewCountDisplay;

--- a/js/popup.js
+++ b/js/popup.js
@@ -15,6 +15,9 @@ const hideDefaultControlsCheckbox = document.querySelector(
 const disableInfiniteLoopCheckbox = document.querySelector(
   '#disable_inifinite_loop',
 );
+const showViewCountCheckbox = document.querySelector(
+  '#show_view_count',
+);
 
 // Load options values.
 chrome.storage.sync
@@ -25,6 +28,7 @@ chrome.storage.sync
     controlVolumeWithArrows: false,
     disableInfiniteLoop: false,
     hideDefaultControls: true,
+    showViewCount: true,
   })
   .then((items) => {
     enabledCheckBox.checked = items.enabled;
@@ -33,6 +37,7 @@ chrome.storage.sync
     controlVolumeArrowCheckbox.checked = items.controlVolumeWithArrows;
     hideDefaultControlsCheckbox.checked = items.hideDefaultControls;
     disableInfiniteLoopCheckbox.checked = items.disableInfiniteLoop;
+    showViewCountCheckbox.checked = items.showViewCount;
 
     updateText();
   });
@@ -68,6 +73,12 @@ hideDefaultControlsCheckbox.addEventListener('change', (e) => {
 disableInfiniteLoopCheckbox.addEventListener('change', (e) => {
   chrome.storage.sync.set({
     disableInfiniteLoop: disableInfiniteLoopCheckbox.checked,
+  });
+});
+
+showViewCountCheckbox.addEventListener('change', (e) => {
+  chrome.storage.sync.set({
+    showViewCount: showViewCountCheckbox.checked,
   });
 });
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "__MSG_AppName__",
-  "version": "2.1.2",
+  "version": "2.1.5",
   "manifest_version": 3,
   "description": "__MSG_AppDescription__",
   "permissions": ["storage", "scripting"],

--- a/scss/content_script.scss
+++ b/scss/content_script.scss
@@ -116,6 +116,13 @@ ytd-shorts[cfyts-enabled='false'] {
   }
 }
 
+// when "show view count" option is disabled
+ytd-shorts[cfyts-enabled='true'][cfyts-show-view-count='false'] {
+  .cfyts-player-controls .view-count-display {
+    display: none !important;
+  }
+}
+
 // setup controls look.
 .cfyts-player-controls {
   position: absolute;
@@ -294,9 +301,25 @@ ytd-shorts[cfyts-enabled='false'] {
     }
 
     .time-display {
-      // font used by youtube.
       font-family: 'YouTube Noto', Roboto, Arial, Helvetica, sans-serif;
       font-size: 13px;
+    }
+
+    .view-count-display {
+      font-family: 'YouTube Noto', Roboto, Arial, Helvetica, sans-serif;
+      font-size: 13px;
+      margin-left: 10px;
+      color: rgba(255, 255, 255, 0.9);
+      display: flex;
+      align-items: center;
+      font-weight: 500;
+      background-color: rgba(0, 0, 0, 0.5);
+      padding: 2px 6px;
+      border-radius: 4px;
+      max-width: 150px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 }


### PR DESCRIPTION
I've added a cool new feature to the extension - now you can choose whether to show or hide the view count in the shorts controls! 

What's new:
- Added a new checkbox in the popup to toggle view count visibility
- The view count will show up in a nice dark bubble next to the time display
- When disabled, the view count will be hidden but all other controls remain the same
- The setting is saved automatically and persists between sessions

The view count is super useful for content creators to track their videos' performance, but sometimes you just want a cleaner look without it. Now you have the choice! 

Let me know if you'd like any tweaks to the styling or behavior.